### PR TITLE
Avoid naming stdext::checked_array_iterator

### DIFF
--- a/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h
+++ b/lumino/LuminoCore/include/LuminoCore/Base/detail/fmt/format.h
@@ -470,7 +470,7 @@ inline auto get_data(Container& c) -> typename Container::value_type* {
   return c.data();
 }
 
-#if defined(_SECURE_SCL) && _SECURE_SCL
+#if defined(_SECURE_SCL) && _SECURE_SCL && (!defined(_MSC_VER) || _MSC_VER < 1951)
 // Make a checked iterator to avoid MSVC warnings.
 template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
 template <typename T>


### PR DESCRIPTION
... which is removed in Visual Studio 2026 18.6.0 / MSVC 19.51