### PR TITLE
Fix CMake configs when not LUMINO_BUILD_ENGINE.

### DIFF
--- a/cmake/LuminoConfig.cmake.in
+++ b/cmake/LuminoConfig.cmake.in
@@ -13,5 +13,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/LuminoTargets.cmake")
 # Combination target
 #-------------------------------------------------------------------------------
 add_library(lumino::Lumino INTERFACE IMPORTED)
-target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoEngine lumino::LuminoCore)
-
+target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoCore)
+if(@LUMINO_BUILD_ENGINE@)
+    target_link_libraries(lumino::Lumino INTERFACE lumino::LuminoEngine)
+endif()


### PR DESCRIPTION
The original intent of this change was written by @jimwang118 in https://github.com/microsoft/vcpkg/pull/29879 but didn't actually hook the setting up.

Note that I can't actually test this due to https://github.com/LuminoEngine/Lumino/issues/221 ; the effect of the mistake above right now is that vcpkg is more or less "always" never including the `lumino::LuminoEngine` target.
